### PR TITLE
Pin ruff and pylint in the project

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2936,4 +2936,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.15"
-content-hash = "463b4fd219a6fff5bf67ebfaf80c9eb5f60cf43ed5865493d444c88c82e76b48"
+content-hash = "4bb2ec1040f076df426bb7c90fbe4ce8fb600551a8a08e6726d264efe6582141"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ pytest-asyncio = "1.4.0"
 prospector-profile-utils = "1.27.0"
 types-pyyaml = "6.0.12.20260518"
 httpx = "0.28.1"
+ruff = "0.16.1"
+pylint = "4.0.6"
 
 [tool.poetry-dynamic-versioning]
 enable = true


### PR DESCRIPTION
Prospector uses ruff and pylint, they should be pinned alongside prospector.