### PR TITLE
Replace --die-on-tool-error by --direct-tool-stdout in prospector

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,7 +80,7 @@ repos:
       - id: prospector
         args:
           - --profile=utils:pre-commit
-          - --die-on-tool-error
+          - --direct-tool-stdout
           - --output-format=pylint
           - --profile=.prospector.yaml
         additional_dependencies:
@@ -99,7 +99,7 @@ repos:
           )
       - id: prospector
         args:
-          - --die-on-tool-error
+          - --direct-tool-stdout
           - --output-format=pylint
           - --profile=utils:tests
           - --profile=utils:pre-commit

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build-dev:  ## Build the image for development (Prospector and pytest)
 
 .PHONY: lint
 lint: build-dev  ## Lint the project with Prospector
-	docker run --rm --volume=$(shell pwd)/redirect:/app/redirect camptocamp/redirect-dev prospector --output=pylint --die-on-tool-error .
+	docker run --rm --volume=$(shell pwd)/redirect:/app/redirect camptocamp/redirect-dev prospector --output=pylint --direct-tool-stdout .
 
 .PHONY: run
 run: build build-dev  ## Run the project to test it


### PR DESCRIPTION
Prospector --die-on-tool-error is replaced by --direct-tool-stdout.