### PR TITLE
Remove unused gopass patterns

### DIFF
--- a/.github/workflows/rebuild.yaml
+++ b/.github/workflows/rebuild.yaml
@@ -30,6 +30,12 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
 
+      - uses: camptocamp/initialise-gopass-summon-action@v2
+        with:
+          ci-gpg-private-key: ${{secrets.CI_GPG_PRIVATE_KEY}}
+          github-gopass-ci-token: ${{secrets.GOPASS_CI_GITHUB_TOKEN}}
+          patterns: docker
+
       - run: echo "${HOME}/.local/bin" >> ${GITHUB_PATH}
       - run: python3 -m pip install --user --requirement=ci/requirements.txt
 

--- a/.github/workflows/rebuild.yaml
+++ b/.github/workflows/rebuild.yaml
@@ -34,7 +34,7 @@ jobs:
         with:
           ci-gpg-private-key: ${{secrets.CI_GPG_PRIVATE_KEY}}
           github-gopass-ci-token: ${{secrets.GOPASS_CI_GITHUB_TOKEN}}
-          patterns: docker
+          patterns: pypi docker
 
       - run: echo "${HOME}/.local/bin" >> ${GITHUB_PATH}
       - run: python3 -m pip install --user --requirement=ci/requirements.txt


### PR DESCRIPTION
`tag-publish` handles PyPI and ghcr.io authentication via OIDC, so the gopass `pypi` and `docker` patterns are unnecessary for those. However, `c2cciutils-publish` still requires Docker credentials for pushing to registries.

This PR removes unused patterns but keeps `docker` where `c2cciutils-publish` is used.