### PR TITLE
Restore poetry-dynamic-versioning plugin extra and downgrade poetry-core to 2.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,5 +88,5 @@ requires-python = ">=3.11"
 dependencies = ["fastapi", "uvicorn", "c2casgiutils", "pydantic-settings", "certifi", "html-sanitizer", "types-pyyaml==6.0.12.20260518", "prometheus-client", "prometheus-fastapi-instrumentator", "sentry-sdk", "anyio", "jinja2"]
 
 [build-system]
-requires = ["poetry-core==2.4.1", "poetry-dynamic-versioning==1.10.0"]
+requires = ["poetry-core==2.4.0", "poetry-dynamic-versioning[plugin]==1.10.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
Restore poetry-dynamic-versioning plugin extra and downgrade poetry-core to 2.4.0.

## Context
- A previous change dropped the `[plugin]` extra from `poetry-dynamic-versioning`; without the extra, poetry-dynamic-versioning is not installed as a poetry-core build plugin in the PEP 517 isolated build environment.
- poetry-core 2.4.1 has version conflicts, so the pin is set back to 2.4.0.

## Implementation Details
- Edit `[build-system].requires` in `pyproject.toml`; existing version pins are kept.
- No change to project dependencies or to the lock file.

## Testing & Validation
- The CI build and publish flows validate the packaging configuration.

## Impact/Risks
- Restores the previously working build configuration; no runtime impact, no configuration change.